### PR TITLE
Skip after_biblio_action if action is 'delete'

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/CatalogingItemCreator.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/CatalogingItemCreator.pm
@@ -63,6 +63,9 @@ sub after_biblio_action {
     my $action = $params->{action};
     my $biblio = $params->{biblio};
 
+    return
+        if $action eq 'delete';
+
     try {
         warn "Koha::Plugin::Com::ByWaterSolutions::CatalogingItemCreator - Checking Biblio " . $biblio->id;
 


### PR DESCRIPTION
`C4::Biblio::DelBiblio` is passing the *delete* action to the hook:

```perl
    _after_biblio_action_hooks({ action => 'delete', biblio_id => $biblionumber });
```

in this case, the plugin should just skip. In fact, it is exploding with a stack trace on *delete* right now.
